### PR TITLE
Prevent 0.0.0.0/8 from being looked up, correct spelling, update example usage

### DIFF
--- a/IPQualityScore/DBReader.py
+++ b/IPQualityScore/DBReader.py
@@ -26,12 +26,12 @@ class DBReader:
 
     def __init__(self, filename:str):
         if not os.path.isfile(filename):
-            raise FileReaderException('Invalid or non existant file name specified. Please check the file and try again')
+            raise FileReaderException('Invalid or nonexistent file name specified. Please check the file and try again')
         
         try:
             self.handler = open(filename,'rb')
         except IOError:
-            raise FileReaderException('Invalid or non existant file name specified. Please check the file and try again')
+            raise FileReaderException('Invalid or nonexistent file name specified. Please check the file and try again')
 
         self.tree_start = None
         self.tree_end = None
@@ -46,13 +46,16 @@ class DBReader:
 
     def Fetch(self, ip:str):
         if not self.IsIPv4(ip) and not self.IsIPv6(ip):
-            raise FileReaderException("Attemtped to look up invalid IP address. Aborting.")
+            raise FileReaderException("Attempted to look up invalid IP address. Aborting.")
         
         if self.ipv6 and not self.IsIPv6(ip):
-            raise FileReaderException("Attemtped to look up IPv4 using IPv6 database file. Aborting.")
+            raise FileReaderException("Attempted to look up IPv4 using IPv6 database file. Aborting.")
         
         if self.ipv6 == False and not self.IsIPv4(ip):
-            raise FileReaderException("Attemtped to look up IPv6 using IPv4 database file. Aborting.")
+            raise FileReaderException("Attempted to look up IPv6 using IPv4 database file. Aborting.")
+        
+        if self.ipv6 == False and ip.startswith("0."):
+            raise FileReaderException("Attempted to look up an IP address in the 0.0.0.0/8 range. Aborting.")
         
         v_literal = self.IP2Literal(ip)
         position = 0
@@ -63,7 +66,7 @@ class DBReader:
         for _ in range(257):
             previous[position] = file_position
             if len(v_literal) <= position:
-                raise IPNotFoundException("Invalid or nonexistant IP address specified for lookup. (EID: 8)")
+                raise IPNotFoundException("Invalid or nonexistent IP address specified for lookup. (EID: 8)")
 
             if v_literal[position] == 0:
                 pos = self.ReadAt(file_position, self.TREE_BYTE_WIDTH)
@@ -97,14 +100,14 @@ class DBReader:
             try:
                 raw = self.ReadAt(file_position, self.record_bytes)
             except Exception:
-                raise IPNotFoundException("Invalid or nonexistant IP address specified for lookup. (EID: 11)")
+                raise IPNotFoundException("Invalid or nonexistent IP address specified for lookup. (EID: 11)")
 
             try:
                 return self.CreateRecord(raw)
 
             except Exception:
-                raise IPNotFoundException("Invalid or nonexistant IP address specified for lookup. (EID: 12)")
-        raise IPNotFoundException("Invalid or nonexistant IP address specified for lookup. (EID: 13)")
+                raise IPNotFoundException("Invalid or nonexistent IP address specified for lookup. (EID: 12)")
+        raise IPNotFoundException("Invalid or nonexistent IP address specified for lookup. (EID: 13)")
         
     def GetColumns(self):
         return self.columns

--- a/README.md
+++ b/README.md
@@ -29,8 +29,18 @@ pip install git+https://github.com/IPQualityScore/PythonIPQSDBReader
             <pre class="highlight markdown"><code>
 from IPQualityScore.DBReader import DBReader
 
-u = DBReader("IPQualityScore-IP-Reputation-Database-IPv4.ipqs").Fetch("8.8.0.0")
-print(u.IsProxy())
+ipv4_client = DBReader("IPQualityScore-IP-Reputation-Database-IPv4.ipqs")
+
+ipv4_record = ipv4_client.Fetch("8.8.0.0")
+
+print(f"IPv4 Is Proxy: {ipv4_record.IsProxy()}")
+
+
+ipv6_client = DBReader("IPQualityScore-IP-Reputation-Database-IPv6.ipqs")
+
+ipv6_record = ipv6_client.Fetch("2001:4860:4860::8888")
+
+print(f"IPv6 Is Proxy: {ipv6_record.IsProxy()}")
             </code></pre>
         </div>
     </div>

--- a/example.py
+++ b/example.py
@@ -1,4 +1,14 @@
 from IPQualityScore.DBReader import DBReader
 
-u = DBReader("IPQualityScore-IP-Reputation-Database-IPv4.ipqs").Fetch("8.8.0.0")
-print(u.IsProxy())
+ipv4_client = DBReader("IPQualityScore-IP-Reputation-Database-IPv4.ipqs")
+
+ipv4_record = ipv4_client.Fetch("8.8.0.0")
+
+print(f"IPv4 Is Proxy: {ipv4_record.IsProxy()}")
+
+
+ipv6_client = DBReader("IPQualityScore-IP-Reputation-Database-IPv6.ipqs")
+
+ipv6_record = ipv6_client.Fetch("2001:4860:4860::8888")
+
+print(f"IPv6 Is Proxy: {ipv6_record.IsProxy()}")


### PR DESCRIPTION
Per issue #277, updated `DBReader.py` with a condition to check the first octet, and if it matches "0.", then abort the lookup.

Additionally made spelling corrections to error messages:
- "non existant" -> "nonexistent"
- "Attemtped" -> "Attempted"

Additionally, clarified the example usage in `example.py` and updated `README.md` to reflect those changes.